### PR TITLE
Fix derive(Enumerable) for unit structs

### DIFF
--- a/enumerable_derive/src/lib.rs
+++ b/enumerable_derive/src/lib.rs
@@ -48,10 +48,10 @@ fn impl_enumerable_for_struct(s: ItemStruct) -> TokenStream {
         Fields::Unit => {
             return quote!(
                 impl Enumerable for #ident {
-                    type Enumerator = std::iter::Empty<Self>;
+                    type Enumerator = std::iter::Once<Self>;
 
                     fn enumerator() -> Self::Enumerator {
-                        std::iter::empty()
+                        std::iter::once(Self)
                     }
                 }
             )

--- a/src/test.rs
+++ b/src/test.rs
@@ -6,7 +6,9 @@ fn collect_all<T: Enumerable>() -> Vec<T> {
 }
 
 /// Assert enumerator yields all elements in order and provides correct size hint.
-fn assert_enumerator_eq_with_size_hint<T: Enumerable + Debug + PartialEq>(expected: impl IntoIterator<Item = T>) {
+fn assert_enumerator_eq_with_size_hint<T: Enumerable + Debug + PartialEq>(
+    expected: impl IntoIterator<Item = T>,
+) {
     let mut expected = expected.into_iter().collect::<Vec<T>>().into_iter();
     let mut iter = T::enumerator();
     loop {
@@ -67,5 +69,42 @@ fn test_enum_derive() {
     assert_eq!(
         collect_all::<TestEnum3>(),
         vec![TestEnum3::A, TestEnum3::B, TestEnum3::C]
+    );
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Enumerable)]
+struct UnitStruct;
+
+#[test]
+fn test_unit_struct_derive() {
+    assert_eq!(collect_all::<UnitStruct>(), vec![UnitStruct]);
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Enumerable)]
+struct StructWithTwoNamedFields {
+    b: bool,
+    u: u8,
+}
+
+#[test]
+fn test_struct_with_two_named_fields_derive() {
+    assert_eq!(
+        collect_all::<StructWithTwoNamedFields>(),
+        <(bool, u8)>::enumerator()
+            .map(|(b, u)| StructWithTwoNamedFields { b, u })
+            .collect::<Vec<_>>()
+    );
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Enumerable)]
+struct StructWithUnnamedFields(u8, bool);
+
+#[test]
+fn test_struct_with_unnamed_fields_derive() {
+    assert_eq!(
+        collect_all::<StructWithUnnamedFields>(),
+        <(u8, bool)>::enumerator()
+            .map(|(u, b)| StructWithUnnamedFields(u, b))
+            .collect::<Vec<_>>()
     );
 }


### PR DESCRIPTION
It should yield single element: self, not empty.

Also add tests for struct derive.