### PR TITLE
Enumerable::ENUMERABLE_SIZE

### DIFF
--- a/enumerable_derive/src/lib.rs
+++ b/enumerable_derive/src/lib.rs
@@ -25,6 +25,8 @@ fn impl_enumerable_for_unit_type(ident: &Ident, value: TokenStream2) -> TokenStr
             fn enumerator() -> Self::Enumerator {
                 std::iter::once(#value)
             }
+
+            const ENUMERABLE_SIZE: usize = 1;
         }
     )
 }
@@ -101,6 +103,8 @@ fn impl_enumerable_for_enum(e: ItemEnum) -> TokenStream2 {
 
                 return ALL_VARIANTS.iter().copied()
             }
+
+            const ENUMERABLE_SIZE: usize = #variants_count;
         }
     )
 }
@@ -197,6 +201,17 @@ fn impl_enumerable_for_struct(s: ItemStruct) -> TokenStream2 {
             fn enumerator() -> Self::Enumerator {
                 #enumerator_struct_ident::new()
             }
+
+            const ENUMERABLE_SIZE: usize = {
+                let size: usize = 1;
+                #(
+                    let size: usize = match size.checked_mul(<#field_types as Enumerable>::ENUMERABLE_SIZE) {
+                        Some(value) => value,
+                        None => panic!("ENUMERABLE_SIZE exceeds usize::MAX"),
+                    };
+                )*
+                size
+            };
         }
 
         #[doc(hidden)]

--- a/src/impl_tuple.rs
+++ b/src/impl_tuple.rs
@@ -16,6 +16,8 @@ impl Enumerable for () {
     fn enumerator() -> Self::Enumerator {
         std::iter::once(())
     }
+
+    const ENUMERABLE_SIZE: usize = 1;
 }
 
 /// Enumerator for `(A,)`.
@@ -45,6 +47,8 @@ where
             a_enumerator: A::enumerator(),
         }
     }
+
+    const ENUMERABLE_SIZE: usize = A::ENUMERABLE_SIZE;
 }
 
 /// This macro generates a fragment of the body of the `calculate_next` method for a tuple enumerator.
@@ -195,6 +199,17 @@ macro_rules! impl_enumerable_for_tuple {
                 fn enumerator() -> Self::Enumerator {
                     Self::Enumerator::new()
                 }
+
+                const ENUMERABLE_SIZE: usize = {
+                    let size = 1usize;
+                    $(
+                        let size: usize = match size.checked_mul($gen::ENUMERABLE_SIZE) {
+                            Some(size) => size,
+                            None => panic!("ENUMERABLE_SIZE exceeds usize::MAX"),
+                        };
+                    )+
+                    size
+                };
             }
         }
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,23 @@ pub trait Enumerable: Copy {
     type Enumerator: Iterator<Item = Self>;
     /// Return an iterator over all possible values of the implementing type.
     fn enumerator() -> Self::Enumerator;
+    /// The number of elements in this enumerable.
+    /// If the number exceeds the `usize::MAX`, accessing this constant fails at compile time.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// use enumerable::Enumerable;
+    /// let array = [0; u8::ENUMERABLE_SIZE];
+    /// ```
+    ///
+    /// This fails to compile:
+    ///
+    /// ```compile_fail
+    /// use enumerable::Enumerable;
+    /// let array = [0; <(usize, usize)>::ENUMERABLE_SIZE];
+    /// ```
+    const ENUMERABLE_SIZE: usize;
 }
 
 /// Macro to implement the `Enumerable` trait for a numeric type.
@@ -63,6 +80,21 @@ macro_rules! impl_enumerable_for_numeric_type {
             fn enumerator() -> Self::Enumerator {
                 <$ty>::MIN..=<$ty>::MAX
             }
+
+            const ENUMERABLE_SIZE: usize =
+                if std::mem::size_of::<$ty>() < std::mem::size_of::<usize>() {
+                    match (<$ty>::MAX.abs_diff(<$ty>::MIN) as usize).checked_add(1) {
+                        Some(size) => size,
+                        None => {
+                            unreachable!()
+                        }
+                    }
+                } else {
+                    panic!(concat!(
+                        stringify!($ty),
+                        "::ENUMERABLE_SIZE exceeds usize::MAX"
+                    ))
+                };
         }
     };
 }
@@ -149,6 +181,8 @@ impl Enumerable for bool {
     fn enumerator() -> Self::Enumerator {
         BoolEnumerator::new()
     }
+
+    const ENUMERABLE_SIZE: usize = 2;
 }
 
 /// This is an implementation of the `Enumerable` trait for `char`.
@@ -168,6 +202,8 @@ impl Enumerable for char {
     fn enumerator() -> Self::Enumerator {
         ('\u{0}'..='\u{D7FF}').chain('\u{E000}'..='\u{10FFFF}')
     }
+
+    const ENUMERABLE_SIZE: usize = 0x10FFFF + 1;
 }
 
 /// `OptionEnumerator` is an iterator over possible values of `Option<T>`.
@@ -222,6 +258,8 @@ where
     fn enumerator() -> Self::Enumerator {
         OptionEnumerator::new()
     }
+
+    const ENUMERABLE_SIZE: usize = T::ENUMERABLE_SIZE + 1;
 }
 
 /// Implementation of the `Enumerable` trait for `Result<T, E>`, with std::iter::Chain and std::iter::Map.
@@ -244,6 +282,8 @@ where
             .map(t)
             .chain(<E as Enumerable>::enumerator().map(e))
     }
+
+    const ENUMERABLE_SIZE: usize = T::ENUMERABLE_SIZE + E::ENUMERABLE_SIZE;
 }
 
 pub use enumerable_derive::*;

--- a/src/test.rs
+++ b/src/test.rs
@@ -46,6 +46,8 @@ mod utils {
 use utils::*;
 
 fn assert_enumerator_eq<T: Enumerable + Debug + PartialEq>(expected: impl IntoIterator<Item = T>) {
+    let expected = Vec::from_iter(expected);
+    assert_eq!(T::ENUMERABLE_SIZE, expected.len());
     let mut expected_iter = expected.into_iter();
     let mut actual_iter = T::enumerator();
 
@@ -97,10 +99,10 @@ fn test_primitive_numeric() {
     assert_enumerator_eq(i16::MIN..=i16::MAX);
     assert_enumerator_eq(u16::MIN..=u16::MAX);
     /*
-        // Very slow, tested locally.
-        assert_enumerator_eq(i32::MIN..=i32::MAX);
-        assert_enumerator_eq(u32::MIN..=u32::MAX);
-     */
+       // Very slow, tested locally.
+       assert_enumerator_eq(i32::MIN..=i32::MAX);
+       assert_enumerator_eq(u32::MIN..=u32::MAX);
+    */
 }
 
 #[test]
@@ -129,20 +131,76 @@ fn test_unit_struct() {
 #[test]
 fn test_structs() {
     assert_enumerator_eq(vec![
-        Struct2 { e3: Enum3::A, e4: Enum4::W }, Struct2 { e3: Enum3::A, e4: Enum4::X },
-        Struct2 { e3: Enum3::A, e4: Enum4::Y }, Struct2 { e3: Enum3::A, e4: Enum4::Z },
-        Struct2 { e3: Enum3::B, e4: Enum4::W }, Struct2 { e3: Enum3::B, e4: Enum4::X },
-        Struct2 { e3: Enum3::B, e4: Enum4::Y }, Struct2 { e3: Enum3::B, e4: Enum4::Z },
-        Struct2 { e3: Enum3::C, e4: Enum4::W }, Struct2 { e3: Enum3::C, e4: Enum4::X },
-        Struct2 { e3: Enum3::C, e4: Enum4::Y }, Struct2 { e3: Enum3::C, e4: Enum4::Z },
+        Struct2 {
+            e3: Enum3::A,
+            e4: Enum4::W,
+        },
+        Struct2 {
+            e3: Enum3::A,
+            e4: Enum4::X,
+        },
+        Struct2 {
+            e3: Enum3::A,
+            e4: Enum4::Y,
+        },
+        Struct2 {
+            e3: Enum3::A,
+            e4: Enum4::Z,
+        },
+        Struct2 {
+            e3: Enum3::B,
+            e4: Enum4::W,
+        },
+        Struct2 {
+            e3: Enum3::B,
+            e4: Enum4::X,
+        },
+        Struct2 {
+            e3: Enum3::B,
+            e4: Enum4::Y,
+        },
+        Struct2 {
+            e3: Enum3::B,
+            e4: Enum4::Z,
+        },
+        Struct2 {
+            e3: Enum3::C,
+            e4: Enum4::W,
+        },
+        Struct2 {
+            e3: Enum3::C,
+            e4: Enum4::X,
+        },
+        Struct2 {
+            e3: Enum3::C,
+            e4: Enum4::Y,
+        },
+        Struct2 {
+            e3: Enum3::C,
+            e4: Enum4::Z,
+        },
     ]);
 
     assert_enumerator_eq(vec![
-        StructTuple2(Enum3::A, Enum4::W), StructTuple2(Enum3::A, Enum4::X),
-        StructTuple2(Enum3::A, Enum4::Y), StructTuple2(Enum3::A, Enum4::Z),
-        StructTuple2(Enum3::B, Enum4::W), StructTuple2(Enum3::B, Enum4::X),
-        StructTuple2(Enum3::B, Enum4::Y), StructTuple2(Enum3::B, Enum4::Z),
-        StructTuple2(Enum3::C, Enum4::W), StructTuple2(Enum3::C, Enum4::X),
-        StructTuple2(Enum3::C, Enum4::Y), StructTuple2(Enum3::C, Enum4::Z),
+        StructTuple2(Enum3::A, Enum4::W),
+        StructTuple2(Enum3::A, Enum4::X),
+        StructTuple2(Enum3::A, Enum4::Y),
+        StructTuple2(Enum3::A, Enum4::Z),
+        StructTuple2(Enum3::B, Enum4::W),
+        StructTuple2(Enum3::B, Enum4::X),
+        StructTuple2(Enum3::B, Enum4::Y),
+        StructTuple2(Enum3::B, Enum4::Z),
+        StructTuple2(Enum3::C, Enum4::W),
+        StructTuple2(Enum3::C, Enum4::X),
+        StructTuple2(Enum3::C, Enum4::Y),
+        StructTuple2(Enum3::C, Enum4::Z),
     ]);
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Enumerable)]
+struct UnitStruct;
+
+#[test]
+fn test_derive_unit_struct() {
+    assert_eq!(collect_all::<UnitStruct>(), vec![UnitStruct]);
 }


### PR DESCRIPTION
Associated constant for the number of values in this enumerable. If the number exceeds `usize::MAX`, accessing the constant fails at compile time.

This is useful to create a compact storage to map all the values:

```
let mut data: [None; MyEnum::ENUMERABLE_SIZE];
```

I chose name `ENUMERABLE_SIZE` not `SIZE` to avoid confusion with possible other meaning of `SIZE` (for example, `for `u32` `SIZE` could also mean size in bytes).

Follow-up to this PR would be implementing:
- `Enumerable::enumerable_index` to map enumerable value to `usize` index
- `Enumerable::enumerable_from_index` for the opposite operation