### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 4
+
+[*.yml]
+indent_size = 2


### PR DESCRIPTION
Mostly to add trailing newlines to files which are not .rs.  Many editors understand `.editorconfig` out of the box.